### PR TITLE
Collapsable column clipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Clip children of CollapsableColumn instead of the column itself. This makes it easier to draw
+  outside it's bounds as well as not have the children overlap other views when you collapse. You
+  can disable this clipping for a specific child with `Modifier.collapse(clip = false)`.
+
 ## [0.1.0] 2023-11-05
 
 ### Added

--- a/app/src/main/java/me/tatarka/android/collapsable/Accordion.kt
+++ b/app/src/main/java/me/tatarka/android/collapsable/Accordion.kt
@@ -85,9 +85,7 @@ fun Accordion(modifier: Modifier = Modifier) {
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.surface)
-                .padding(start = 16.dp)
+            modifier = Modifier.padding(start = 16.dp)
         ) {
             ProvideTextStyle(MaterialTheme.typography.titleLarge) {
                 Text("Title")

--- a/app/src/main/java/me/tatarka/android/collapsable/PinnedTabsTopAppBar.kt
+++ b/app/src/main/java/me/tatarka/android/collapsable/PinnedTabsTopAppBar.kt
@@ -2,18 +2,24 @@
 
 package me.tatarka.android.collapsable
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarColors
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -29,12 +35,16 @@ fun PinnedTabsTopAppBar(
     modifier: Modifier = Modifier,
 ) {
     var selectedTab by remember { mutableIntStateOf(0) }
-    CollapsableColumn(behavior = collapsableBehavior, modifier = modifier) {
+    CollapsableColumn(
+        behavior = collapsableBehavior,
+        modifier = modifier.background(MaterialTheme.colorScheme.surface)
+    ) {
         TopAppBar(
             title = { Text("Title") },
+            colors = TopAppBarDefaults.smallTopAppBarColors(containerColor = Color.Transparent),
             navigationIcon = {
                 NavigateBackButton(onClick = onNavigateBack)
-            }
+            },
         )
         Text(
             text = "Here's some content between the app bar title and tabs that should collapse out of the way.",
@@ -62,6 +72,31 @@ fun PinnedTabsTopAppBarPreview() {
         Page(
             modifier = Modifier.nestedScroll(collapsableBehavior.nestedScrollConnection),
             topBar = { PinnedTabsTopAppBar(collapsableBehavior, onNavigateBack = {}) }
+        )
+    }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+fun MultipleCollapsableChildrenClippingPreview() {
+    CollapsableTheme {
+        val collapsableBehavior = rememberCollapsableBehavior()
+        Page(
+            modifier = Modifier.nestedScroll(collapsableBehavior.nestedScrollConnection),
+            topBar = {
+                Column(modifier = Modifier.background(Color.White)) {
+                    Text("Content above the collapsable that should not be overlapped")
+                    CollapsableColumn(behavior = collapsableBehavior) {
+                        Text("This should also not overlap")
+                        Text("This should collapse and be clipped", modifier = Modifier.collapse())
+                        Text(
+                            "This should also collapse but not be clipped",
+                            modifier = Modifier.collapse(clip = false)
+                        )
+                        Text("This should stick around")
+                    }
+                }
+            }
         )
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "me.tatarka.compose.collapsable"
-version = "0.1.0"
+version = "0.2.0-SNAPSHOT"
 
 nexusPublishing {
     repositories {


### PR DESCRIPTION
Clip children of CollapsableColumn instead of the column itself. This makes it easier to draw
  outside it's bounds as well as not have the children overlap other views when you collapse. You
  can disable this clipping for a specific child with `Modifier.collapse(clip = false)`.

Fixes #8 